### PR TITLE
feat: Add duckduckgo-search and wikipedia packages to backend

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -104,3 +104,5 @@ uvicorn
 wcwidth
 werkzeug
 yarl
+duckduckgo-search
+wikipedia


### PR DESCRIPTION
There were some dependencies missing on the backend requirements.